### PR TITLE
Fix missing closure in UniversalTestClient component

### DIFF
--- a/client/src/components/UniversalTestClient.jsx
+++ b/client/src/components/UniversalTestClient.jsx
@@ -1168,4 +1168,6 @@ const SqlWorkspace = ({ connection }) => {
   );
 };
 
+};
+
 export default UniversalTestClient;


### PR DESCRIPTION
## Summary
- close `UniversalTestClient` definition so exports are top-level

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6853c1621ec0832d8609a8673833f1ea