### PR TITLE
Fix HMR configuration for remote dev access

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -5,13 +5,12 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   base: '/unicon/',
   plugins: [react()],
- server: {
+  server: {
     port: 5174,
     host: '0.0.0.0', // Wichtig: Erlaubt Zugriff von anderen IPs
     strictPort: true,
     hmr: {
-      port: 5174,
-      host: 'localhost' // Für HMR verwende localhost
+      port: 5174 // Nutzt automatisch den Host der aufrufenden Seite
     },
     proxy: {
    '/unicon/api': {


### PR DESCRIPTION
## Summary
- tweak vite config so HMR uses the page's hostname

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint src` *(fails: eslint config error)*

------
https://chatgpt.com/codex/tasks/task_e_6853c463f57c832dbd983a9b58cea0cb